### PR TITLE
Ignore localStorage exceptions when persisting across refreshes as this is an optional feature

### DIFF
--- a/src/tools/visionTool.ts
+++ b/src/tools/visionTool.ts
@@ -945,12 +945,24 @@ async function computeShadow(event: any)
             items[0].commands = commands;
         });
 
-        localStorage.setItem(`${Constants.EXTENSIONID}/fogCache/${sceneCache.userId}/${sceneId}`, JSON.stringify([{digest: 'reuse', commands: commands}]));
+        try {
+            localStorage.setItem(`${Constants.EXTENSIONID}/fogCache/${sceneCache.userId}/${sceneId}`, JSON.stringify([{digest: 'reuse', commands: commands}]));
+        }
+        catch (error)
+        {
+        }
+
         newPath.delete();
         reuseNewFog.delete();
     } else if (persistenceEnabled) {
         const saveFog = localItemCache.filter(isVisionFog);
-        localStorage.setItem(`${Constants.EXTENSIONID}/fogCache/${sceneCache.userId}/${sceneId}`, JSON.stringify(saveFog.map((item: any) => { return {digest: item.metadata[`${Constants.EXTENSIONID}/digest`], commands: item.commands}; })));
+        try
+        {
+            localStorage.setItem(`${Constants.EXTENSIONID}/fogCache/${sceneCache.userId}/${sceneId}`, JSON.stringify(saveFog.map((item: any) => { return {digest: item.metadata[`${Constants.EXTENSIONID}/digest`], commands: item.commands}; })));
+        }
+        catch (error)
+        {
+        }
     }
 
     let currentFogPath: any;


### PR DESCRIPTION
Looks like using localstorage to save the state of fog persistence between refreshes is causing issues, however it's safe to ignore any exceptions thrown because it's not really a required feature.