### PR TITLE
Full occlusion support and fixes for Fast mode

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -405,13 +405,6 @@ li>p {
     cursor: pointer;
 }
 
-#forceAccurate {
-    padding-left: 8px;
-    font-weight: bold;
-    color: red;
-    cursor: not-allowed;
-}
-
 @keyframes glow {
     0% {
         box-shadow: 0 0 2px 0px red;

--- a/src/smokeHandlers.ts
+++ b/src/smokeHandlers.ts
@@ -4,7 +4,7 @@ import * as Utilities from "./utilities/utilities";
 import { SMOKEMAIN } from "./smokeMain";
 import { sceneCache } from "./utilities/globals";
 import { Constants } from "./utilities/constants";
-import { isAnyFog, isTorch, isTrailingFog } from "./utilities/itemFilters";
+import { isAnyFog, isTrailingFog } from "./utilities/itemFilters";
 import { importFog, updateMaps } from "./tools/import";
 import { InitializeScene } from "./smokeInitializeScene";
 import { OnSceneDataChange } from './tools/smokeVisionProcess';
@@ -81,7 +81,6 @@ export function SetupOBROnChangeHandlers(role: "GM" | "PLAYER")
     const sceneItemsHandler = OBR.scene.items.onChange(async (items) =>
     {
         sceneCache.items = items;
-        sceneCache.torchActive = items.some(isTorch);
 
         if (sceneCache.ready)
         {
@@ -89,16 +88,6 @@ export function SetupOBROnChangeHandlers(role: "GM" | "PLAYER")
             {
                 await SMOKEMAIN.UpdateUI();
                 await updateMaps(SMOKEMAIN.mapAlign!);
-                if (sceneCache.torchActive)
-                {
-                    SMOKEMAIN.qualityOption!.style.display = "none";
-                    SMOKEMAIN.torchQuality!.style.display = "inline-block";
-                }
-                else
-                {
-                    SMOKEMAIN.qualityOption!.style.display = "inline-block";
-                    SMOKEMAIN.torchQuality!.style.display = "none";
-                }
             }
             else
             {
@@ -271,7 +260,8 @@ export function SetupMainHandlers()
         const target = event.target as HTMLInputElement;
         if (target.value === "fast")
         {
-            await OBR.notification.show("Notice: Issues can occur when using FAST Performance with PERSISTENCE, specifically with revealing inner fogged areas when traveling in a full circle around them. Use both with caution and care.", "DEFAULT");
+            // This has been fixed, so lets not scare anyone away anymore:
+            // await OBR.notification.show("Notice: Issues can occur when using FAST Performance with PERSISTENCE, specifically with revealing inner fogged areas when traveling in a full circle around them. Use both with caution and care.", "DEFAULT");
         }
 
         await OBR.scene.setMetadata({ [`${Constants.EXTENSIONID}/quality`]: target.value });

--- a/src/smokeHandlers.ts
+++ b/src/smokeHandlers.ts
@@ -258,11 +258,6 @@ export function SetupMainHandlers()
     {
         if (!event || !event.target) return;
         const target = event.target as HTMLInputElement;
-        if (target.value === "fast")
-        {
-            // This has been fixed, so lets not scare anyone away anymore:
-            // await OBR.notification.show("Notice: Issues can occur when using FAST Performance with PERSISTENCE, specifically with revealing inner fogged areas when traveling in a full circle around them. Use both with caution and care.", "DEFAULT");
-        }
 
         await OBR.scene.setMetadata({ [`${Constants.EXTENSIONID}/quality`]: target.value });
     };

--- a/src/smokeMain.ts
+++ b/src/smokeMain.ts
@@ -1,6 +1,6 @@
 import OBR, { Item, Player, isImage } from "@owlbear-rodeo/sdk";
 import { sceneCache } from './utilities/globals';
-import { isTokenWithVisionForUI, isTorch } from './utilities/itemFilters';
+import { isTokenWithVisionForUI } from './utilities/itemFilters';
 import { OnSceneDataChange } from './tools/smokeVisionProcess';
 import { Constants } from "./utilities/constants";
 import { SetupSpectreGM } from "./spectreMain";
@@ -39,7 +39,6 @@ export class SmokeMain
     public doorCheckbox?: HTMLInputElement;
     public fowColor?: HTMLInputElement;
     public qualityOption?: HTMLSelectElement;
-    public torchQuality?: HTMLDivElement;
     public resetButton?: HTMLInputElement;
     public convertButton?: HTMLInputElement;
     public settingsButton?: HTMLInputElement;
@@ -111,7 +110,6 @@ export class SmokeMain
         this.doorCheckbox = document.getElementById("door_checkbox") as HTMLInputElement;
         this.fowColor = document.getElementById("fow_color") as HTMLInputElement;
         this.qualityOption = document.getElementById("quality") as HTMLSelectElement;
-        this.torchQuality = document.getElementById("forceAccurate") as HTMLDivElement;
         this.resetButton = document.getElementById("persistence_reset") as HTMLInputElement;
         this.convertButton = document.getElementById("convert_button") as HTMLInputElement;
         this.settingsButton = document.getElementById("settings_button") as HTMLInputElement;
@@ -277,18 +275,6 @@ export class SmokeMain
         for (const player of playersWithVision)
         {
             AddUnitVisionUI(player);
-        }
-
-        sceneCache.torchActive = sceneCache.items.some(isTorch);
-        if (sceneCache.torchActive)
-        {
-            SMOKEMAIN.qualityOption!.style.display = "none";
-            SMOKEMAIN.torchQuality!.style.display = "inline-block";
-        }
-        else
-        {
-            SMOKEMAIN.qualityOption!.style.display = "inline-block";
-            SMOKEMAIN.torchQuality!.style.display = "none";
         }
     }
 

--- a/src/tools/smokeCreateObstructions.ts
+++ b/src/tools/smokeCreateObstructions.ts
@@ -1,9 +1,55 @@
-import { Vector2, MathM, Math2 } from "@owlbear-rodeo/sdk";
+import OBR, { buildPath, Vector2, MathM, Math2 } from "@owlbear-rodeo/sdk";
 import { Constants } from "../utilities/constants";
 import { sceneCache } from "../utilities/globals";
 import { isTorch } from "../utilities/itemFilters";
 import { comparePosition, squareDistance, isClose, mod } from "../utilities/math";
-import { playerShadowCache } from "./smokeVisionProcess";
+import { playerShadowCache, PathKit } from "./smokeVisionProcess";
+
+
+function CheckLineOcclusionByPoly(line: Vector2[], poly: Vector2[]): boolean
+{
+    if (Math2.pointInPolygon(line[0], poly) || Math2.pointInPolygon(line[0], poly))
+    {
+        return true;
+    }
+
+    return LineIntersect(line, [poly[0], poly[1]]) || LineIntersect(line, [poly[1], poly[2]]) || LineIntersect(line, [poly[2], poly[3]]) || LineIntersect(line, [poly[3], poly[0]]);
+}
+
+function LineIntersect(l1: Vector2[], l2: Vector2[]): boolean
+{
+    const det = (l1[1].x - l1[0].x) * (l2[1].y - l2[0].y) - (l2[1].x - l2[0].x) * (l1[1].y - l1[0].y);
+    const a = ((l2[1].y - l2[0].y) * (l2[1].x - l1[0].x) + (l2[0].x - l2[1].x) * (l2[1].y - l1[0].y)) / det;
+    const b = ((l1[0].y - l1[1].y) * (l2[1].x - l1[0].x) + (l1[1].x - l1[0].x) * (l2[1].y - l1[0].y)) / det;
+
+    return a >= 0 && a <= 1 && b >= 0 && b <= 1;
+}
+
+// find either side of the circle from the perspective of a given angle
+function CalculatePointOnCircle(center: Vector2, radius: number, angle: number): Vector2
+{
+    return { x: center.x + radius * Math.cos(angle), y: center.y + radius * Math.sin(angle) };
+}
+
+// create a rect that starts at p1*radius and extends around the p2*radius
+function GetRectFromPoints(p1: Vector2, r1: number, p2: Vector2, r2: number): Vector2[]
+{
+    const angle = Math.atan2(p1.y - p2.y, p1.x - p2.x);
+
+    let p1p1 = CalculatePointOnCircle(p1, r1, angle + Math.PI / 2);
+    let p1p2 = CalculatePointOnCircle(p1, r1, angle - Math.PI / 2);
+    let p2p1 = CalculatePointOnCircle(p2, r2, angle + Math.PI / 2);
+    let p2p2 = CalculatePointOnCircle(p2, r2, angle - Math.PI / 2);
+
+    const direction: Vector2 = Math2.normalize(Math2.subtract(p1, p2));
+    p1p1 = Math2.add(p1p1, Math2.multiply(direction, r1));
+    p1p2 = Math2.add(p1p2, Math2.multiply(direction, r1));
+
+    p2p1 = Math2.add(p2p1, Math2.multiply(direction, 0-r2));
+    p2p2 = Math2.add(p2p2, Math2.multiply(direction, 0-r2));
+
+    return [p1p1, p1p2, p2p2, p2p1];
+}
 
 export function CreateObstructionLines(visionShapes: any): ObstructionLine[]
 {
@@ -37,7 +83,6 @@ export function CreatePolygons(visionLines: ObstructionLine[], tokensWithVision:
     let lineCounter = 0, skipCounter = 0;
     let size = [width, height];
     const gmIds = sceneCache.players.filter(x => x.role === "GM");
-    const useOptimisations = sceneCache.metadata[`${Constants.EXTENSIONID}/quality`] !== 'accurate';
 
     const corners = [
         { x: (width + offset[0]) * scale[0], y: offset[1] * scale[1] },
@@ -51,6 +96,13 @@ export function CreatePolygons(visionLines: ObstructionLine[], tokensWithVision:
     const extensionId = Constants.EXTENSIONID;
 
     const sceneHasTorches = tokensWithVision.some(isTorch);
+
+    // Now witness the firepower of this fully armed and operational battlestation:
+    const debugOcclusion: boolean = false;
+    let debugPath;
+    if (debugOcclusion) {
+        debugPath = PathKit.NewPath();
+    }
 
     if (tokensWithVision.length === 0)
     {
@@ -84,6 +136,41 @@ export function CreatePolygons(visionLines: ObstructionLine[], tokensWithVision:
             visionRange = gridDpi * ((visionRangeMeta) / sceneCache.gridScale + 0.5);
         }
 
+        const torchBounds:Vector2[][] = [];
+        if (sceneHasTorches && !isTorch(token))
+        {
+            for (const torch of tokensWithVision)
+            {
+                if (isTorch(torch))
+                {
+                    const torchVisionRangeMeta = torch.metadata[`${Constants.EXTENSIONID}/visionRange`];
+
+                    // use the token vision range to potentially skip any obstruction lines out of range:
+                    let torchVisionRange = 1000 * sceneCache.gridDpi;
+                    if (torchVisionRangeMeta) {
+                        torchVisionRange = sceneCache.gridDpi * ((torchVisionRangeMeta) / sceneCache.gridScale + .5);
+                    }
+
+                    // Create the bounds of the torch and scale the occlusion radius slightly:
+                    const torchBoundingRect = GetRectFromPoints(token.position, visionRange, torch.position, torchVisionRange);
+                    torchBounds.push(torchBoundingRect);
+
+                    if (debugOcclusion) {
+                        let path = PathKit.NewPath();
+                        path.moveTo(torchBoundingRect[0].x, torchBoundingRect[0].y)
+                            .lineTo(torchBoundingRect[1].x, torchBoundingRect[1].y)
+                            .lineTo(torchBoundingRect[2].x, torchBoundingRect[2].y)
+                            .lineTo(torchBoundingRect[3].x, torchBoundingRect[3].y)
+                            .closePath();
+
+                        const debugp = buildPath().fillRule("evenodd").commands(path.toCmds()).visible(true).fillColor('#660000').strokeColor("#FF0000").fillOpacity(0.2).layer("DRAWING").name("smokedebug").metadata({[`${Constants.EXTENSIONID}/debug`]: true}).build();
+                        OBR.scene.local.addItems([debugp]);
+                        path.delete();
+                    }
+                }
+            }
+        }
+
         for (const line of visionLines)
         {
             const signedDistance = (token.position.x - line.startPosition.x) * (line.endPosition.y - line.startPosition.y) - (token.position.y - line.startPosition.y) * (line.endPosition.x - line.startPosition.x);
@@ -103,33 +190,47 @@ export function CreatePolygons(visionLines: ObstructionLine[], tokensWithVision:
                 continue;
             }
 
-            // exclude lines based on distance.. this is faster than creating polys around everything, but is less accurate, particularly on long lines
-            if (useOptimisations && (!sceneHasTorches || isTorch(token)))
+            // exclude lines based on distance.. this is faster than creating polys around everything, but is less accurate, particularly on long lines. we compensate for this by adjusting the detection by 5% of the vision range.
+            const segments: Vector2[] = [line.startPosition, line.endPosition];
+            const length = Math2.distance(line.startPosition, line.endPosition);
+            const segmentFactor = 3; // this causes load but increases accuracy, because we calculate maxSegments as a proportion of the visionRange divided by the segment factor to increase resolution
+            const maxSegments = Math.floor(length / (visionRange / segmentFactor));
+
+            for (let i = 1; i < maxSegments; i++)
             {
-                const segments: Vector2[] = [line.startPosition, line.endPosition];
-                const length = Math2.distance(line.startPosition, line.endPosition);
-                const segmentFactor = 3; // this causes load but increases accuracy, because we calculate maxSegments as a proportion of the visionRange divided by the segment factor to increase resolution
-                const maxSegments = Math.floor(length / (visionRange / segmentFactor));
+                segments.push(Math2.lerp(line.startPosition, line.endPosition, (i / maxSegments)));
+            }
 
-                for (let i = 1; i < maxSegments; i++)
+            let skip = true;
+            for (const segment of segments)
+            {
+                // add 5% to the visionRange as a precaution:
+                if (Math2.compare(token.position, segment, visionRange * 1.05))
                 {
-                    segments.push(Math2.lerp(line.startPosition, line.endPosition, (i / maxSegments)));
+                    skip = false;
+                    break;
                 }
+            };
 
-                let skip = true;
-                for (const segment of segments)
-                {
-                    if (Math2.compare(token.position, segment, visionRange))
+
+            // if the token we're calculating is not a torch, then check torch occlusion based on the bounding triangles
+            if (skip && sceneHasTorches && !isTorch(token)) {
+                for (const bounds of torchBounds) {
+                    if (CheckLineOcclusionByPoly([line.startPosition, line.endPosition], bounds))
                     {
                         skip = false;
+                        break;
                     }
-                };
-
-                if (skip)
-                {
-                    skipCounter++;
-                    continue;
                 }
+            }
+
+            if (skip)
+            {
+                if (debugOcclusion) {
+                    debugPath.moveTo(line.startPosition.x, line.startPosition.y).lineTo(line.endPosition.x, line.endPosition.y);
+                }
+                skipCounter++;
+                continue;
             }
 
             lineCounter++;
@@ -226,6 +327,16 @@ export function CreatePolygons(visionLines: ObstructionLine[], tokensWithVision:
 
             polygons[polygons.length - 1].push({ pointset: pointset, fromShape: line.originalShape });
         }
+    }
+
+    if (debugOcclusion)
+    {
+        console.log('skip', skipCounter, 'lines', lineCounter);
+
+        const debugp = buildPath().commands(debugPath.toCmds()).visible(true).strokeColor("#00FF00").fillOpacity(0).layer("DRAWING").name("smokedebug").metadata({[`${Constants.EXTENSIONID}/debug`]: true}).build();
+        OBR.scene.local.addItems([debugp]);
+
+        debugPath.delete();
     }
 
     return polygons;

--- a/src/tools/smokeVisionProcess.ts
+++ b/src/tools/smokeVisionProcess.ts
@@ -411,15 +411,15 @@ async function ComputeShadow(eventDetail: Detail)
     const sceneId = sceneCache.metadata[`${Constants.EXTENSIONID}/sceneId`];
     if (enableReuseFog)
     {
+        const newPath = reuseNewFog.resolve();
+        newPath.setFillType(PathKit.FillType.EVENODD);
+
         // Warning: the order of these operations affects the outcome in PathKit (even though it probably shouldnt).
         // the path visible by the player needs to get added first before the old path gets added.
         if (oldPath !== null)
         {
-            reuseNewFog.add(oldPath, PathKit.PathOp.UNION);
+            newPath.op(oldPath, PathKit.PathOp.UNION);
         }
-
-        const newPath = reuseNewFog.resolve();
-        newPath.setFillType(PathKit.FillType.EVENODD);
 
         const commands = newPath.toCmds();
 

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -151,7 +151,7 @@ export class Constants
                         <td colspan="2">Performance<select id="quality">
                             <option value="accurate" selected>Accurate</option>
                             <option value="fast">Fast</option>
-                        </select><div id="forceAccurate" style="display: none;" title="A token is being used as a 'Light Source' and Performance is locked in 'Accuracy Mode'."> Torch-Mode</div></td>
+                        </select></td>
                         <td colspan="2"><input class="settingsButton" type="button" id="debug_button" value="Enable Debugging" title="Show debugging and performance data"></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
- Occlusion now fully supports torches and works in both fast/accurate mode.
- forceAccurate is unnecessary now, since torches are supported
- Fast mode rendering bugs fixed - notably both the fill issue that would reveal too much, and the case where parts of the fog paths would occasionally get inverted
- Between the two changes, I think we can change rendering back to 'Fast', so I removed the warning but didn't change the default yet
